### PR TITLE
Check correct event for mouse button

### DIFF
--- a/src/directives/longclick.js
+++ b/src/directives/longclick.js
@@ -11,7 +11,7 @@ export default ({delay = 400, interval = 50}) => ({
     let pressInterval = null
 
     const start = (e) => {
-      if (e.type === 'click' && e.button !== 0) {
+      if (e.type === 'mousedown' && e.button !== 0) {
         return
       }
 


### PR DESCRIPTION
`start` is never called with a `click` event, so check `mousedown` instead